### PR TITLE
Catch and log spawn failures

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,14 @@ var util = require("util");
 var spawn = require("child_process").spawn;
 
 var doSpawn = function(callback){
-  var child = spawn('child.js');
+  var child = spawn('child.js')
+    .on('error', function (err) {
+      console.log(err.syscall + ' returned ' + err.errno);
+    });
+
+  child.stdin.on('error', function (err) {
+    console.log(err.syscall + ' returned ' + err.errno);
+  });
 
   child.on('exit', function(code){
     console.log("Child exited with code " + code);


### PR DESCRIPTION
> I have no idea why this `EPIPE` error is getting raised, or how to fix it. I'm spawning a child process using spawn `child.js` …

It seems quite a few people have run into this issue over the past three years, including myself. (#1)

First, the child process isn't getting spawned at all.  `spawn('child.js')` fails, but the `ENOENT` is masked, as the `EPIPE` is raised first.

`spawn('node', ['child.js'])` would work as intended, but why is `EPIPE` raised at all?

The lamented W. Richard Stevens writes in “Advanced Programming in the UNIX Environment”:

> If we `write` to a pipe whose read end has been closed, the signal `SIGPIPE` is generated. If we either ignore the signal or catch it and return from the signal handler, `write` returns −1 with `errno` set to `EPIPE`.

The attached patch shows how to catch both the `EPIPE` and the `ENOENT`.
